### PR TITLE
when comparing objectId's always use 'equals'

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -136,7 +136,7 @@ function plugin(schema, options) {
         var hasRole = false;
         if (obj.roles) {
           obj.roles.forEach(function (r) {
-            if (r.id === role.id) hasRole = true;
+            if (role._id.equals(r._id)) hasRole = true;
           });
         }
         done(null, hasRole);


### PR DESCRIPTION
see mongoose documentation
